### PR TITLE
Fixed duplication of field Actions in inlines

### DIFF
--- a/inline_actions/admin.py
+++ b/inline_actions/admin.py
@@ -103,13 +103,15 @@ class InlineActionsMixin(InlineAdminCompat):
 
         fields = super(InlineActionsMixin, self).get_fields(request, obj)
         fields = list(fields)
-        fields.append('render_actions')
+        if 'render_actions' not in fields:
+            fields.append('render_actions')
         return fields
 
     def get_readonly_fields(self, request, obj=None):
         fields = super(InlineActionsMixin, self).get_readonly_fields(request, obj)
         fields = list(fields)
-        fields.append('render_actions')
+        if 'render_actions' not in fields:
+            fields.append('render_actions')
         return fields
 
     def render_actions(self, obj=None):


### PR DESCRIPTION
In Django 1.10.1 adding of 'render_actions' causes duplication of field 'Action' in admin inlines