### PR TITLE
Skip adding inline actions into create form

### DIFF
--- a/inline_actions/admin.py
+++ b/inline_actions/admin.py
@@ -72,7 +72,7 @@ class BaseInlineActionsMixin:
         """
         Renders all defined inline actions as html.
         """
-        if not obj:
+        if not (obj and obj.pk):
             return ''
 
         buttons = []

--- a/test_proj/blog/tests/test_admin.py
+++ b/test_proj/blog/tests/test_admin.py
@@ -171,3 +171,11 @@ def test_delete_action(admin_client, mocker, article):
     assert response.request.path == author_url
     with pytest.raises(Article.DoesNotExist):
         Article.objects.get(pk=article.pk)
+
+
+def test_skip_rendering_actions_for_unsaved_objects(admin_client, mocker, article):
+    from test_proj.blog.admin import ArticleAdmin
+    unsaved_article = Article()
+    admin = ArticleAdmin(unsaved_article, admin_site)
+
+    assert admin.render_inline_actions(unsaved_article) == ''


### PR DESCRIPTION
Creating new rows in inline admin renders inline action buttons with unsaved object. If a user clicks an inline action button the exception will be raised because object used for creating button on add form does not exists (`obj.pk` is actually `None`). This PR fixes that. If the object does not exist there won't be any inline actions added to the form.

Also, I think this fix should be implemented for 1.x version.
