### PR TITLE
Skip adding inline actions into create form for Django 1.x

### DIFF
--- a/inline_actions/admin.py
+++ b/inline_actions/admin.py
@@ -73,7 +73,7 @@ class BaseInlineActionsMixin(InlineAdminCompat):
         """
         Renders all defined inline actions as html.
         """
-        if not obj:
+        if not (obj and obj.pk):
             return ''
 
         buttons = []

--- a/test_proj/blog/tests/test_admin.py
+++ b/test_proj/blog/tests/test_admin.py
@@ -171,3 +171,11 @@ def test_delete_action(admin_client, mocker, article):
     assert response.request.path == author_url
     with pytest.raises(Article.DoesNotExist):
         Article.objects.get(pk=article.pk)
+
+
+def test_skip_rendering_actions_for_unsaved_objects(admin_client, mocker, article):
+    from test_proj.blog.admin import ArticleAdmin
+    unsaved_article = Article()
+    admin = ArticleAdmin(unsaved_article, admin_site)
+
+    assert admin.render_inline_actions(unsaved_article) == ''


### PR DESCRIPTION
This is absolutely the same as #9 only for Django version 1.x