### PR TITLE
Fix ModelAdmin asset definition

### DIFF
--- a/inline_actions/admin.py
+++ b/inline_actions/admin.py
@@ -151,16 +151,12 @@ class InlineActionsMixin(BaseInlineActionsMixin):
 
 
 class InlineActionsModelAdminMixin(BaseInlineActionsMixin):
-    @property
-    def media(self):
-        media = super().media
+    class Media:
         css = {
             "all": (
                 "inline_actions/css/inline_actions.css",
             )
         }
-        media.add_css(css)
-        return media
 
     def get_list_display(self, request):
         # store `request` for `get_inline_actions`


### PR DESCRIPTION
Media files weren't loading properly (eg missing ModelAdmin js files) because there is no `add_css` method anymore. It's changed now as per doc: https://docs.djangoproject.com/en/2.0/ref/contrib/admin/#modeladmin-asset-definitions