### PR TITLE
support for handling additional, non-descript, attribute properties t…

### DIFF
--- a/inline_actions/admin.py
+++ b/inline_actions/admin.py
@@ -105,6 +105,17 @@ class BaseInlineActionsMixin:
                 except AttributeError:
                     css_classes = ''
 
+            # Add per-object attribute support
+            attr_handler = getattr(
+                self, 'get_{}_attr'.format(action_name), None)
+            if callable(attr_handler):
+                attribute_properties = attr_handler(obj=obj)
+            else:
+                try:
+                    attribute_properties = action_func.attribute_properties
+                except AttributeError:
+                    attribute_properties = ''
+
             # If the form is submitted, we have no information about the
             # requested action.
             # Hence we need all data to be encoded using the action name.
@@ -116,10 +127,11 @@ class BaseInlineActionsMixin:
                 str(obj.pk)
             ]
             buttons.append(
-                '<input type="submit" name="{}" value="{}" class="{}">'.format(
+                '<input type="submit" name="{}" value="{}" class="{}" {}>'.format(
                     '_action__{}'.format('__'.join(action_data)),
                     description,
                     css_classes,
+                    attribute_properties
                 )
             )
         return mark_safe('<div class="submit_row inline_actions">{}</div>'.format(


### PR DESCRIPTION
…o the buttons

I needed a way to have actions take place in a new browser window, but since I may want to have other attributes in the future, seemed to me that being able to add generic attribute tags could be useful for other things. 

For example, if my action is named `validate_ercd`, then I can now add an attribute like so:
```
def get_validate_ercd_attr(self, obj):
    return 'formtarget="_blank"'
```
This causes the record to be opened in a new browser window instead of the current browser window.
