### PR TITLE
 ModelAdminMixin: Only remove 'render_inline_actions' if exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+* Do not break if `render_inline_actions` field is missing, thanks to @tony
+
 ### Added
 
 * support for django 3.x

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,4 +6,5 @@
 - [@nikbora](https://github.com/nikbora)
 - [@orwald-sergesson](https://github.com/torwald-sergesson)
 - [@sobolevn](https://github.com/sobolevn)
+- [@tony](https://github.com/tony)
 - [@tripliks](https://github.com/tripliks)

--- a/inline_actions/admin.py
+++ b/inline_actions/admin.py
@@ -176,7 +176,8 @@ class InlineActionsModelAdminMixin(BaseInlineActionsMixin):
             # django adds all readonly fields by default
             # if `self.fields` is not defined we don't want to include
             # `render_inline_actions
-            fields.remove('render_inline_actions')
+            if 'render_inline_actions' in fields:
+                fields.remove('render_inline_actions')
         return fields
 
     def _execute_action(self, request, model_admin, action, obj, parent_obj=None):


### PR DESCRIPTION
## Description

Do not break if customisation removed the `render_inline_actions` field.

Fixes #39

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Code builds clean without any errors or warnings
- [x] Documentation has been updated
- [x] Changes have been added to the `CHANGELOG.md`
- [x] You added yourself to the `CONTRIBUTORS.md`
