### PR TITLE
refactor: remove RemovedInDjango40Warning warning message

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -8,3 +8,4 @@
 - [@sobolevn](https://github.com/sobolevn)
 - [@tony](https://github.com/tony)
 - [@tripliks](https://github.com/tripliks)
+- [@Ivan-Feofanov](https://github.com/Ivan-Feofanov)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Since `unpublish` depends on `article.status` we must use `get_inline_actions` t
 
 ```python
 from django.contrib import admin, messages
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class ArticleInline(InlineActionsMixin,

--- a/inline_actions/actions.py
+++ b/inline_actions/actions.py
@@ -3,7 +3,7 @@ from typing import Callable, List, Optional, Union
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.urls import reverse
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class ViewAction:

--- a/inline_actions/admin.py
+++ b/inline_actions/admin.py
@@ -7,7 +7,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.utils.text import capfirst
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class InlineActionException(Exception):

--- a/test_proj/blog/admin.py
+++ b/test_proj/blog/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin, messages
 from django.shortcuts import render
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from inline_actions.actions import DefaultActionsMixin, ViewAction
 from inline_actions.admin import InlineActionsMixin, InlineActionsModelAdminMixin

--- a/test_proj/blog/models.py
+++ b/test_proj/blog/models.py
@@ -1,5 +1,5 @@
 from django.db import models
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 
 class Author(models.Model):

--- a/test_proj/urls.py
+++ b/test_proj/urls.py
@@ -1,6 +1,6 @@
-from django.conf.urls import url
 from django.contrib import admin
+from django.urls import re_path
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
+    re_path(r'^admin/', admin.site.urls),
 ]

--- a/test_proj/urls.py
+++ b/test_proj/urls.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
-from django.urls import re_path
+from django.urls import path
 
 urlpatterns = [
-    re_path(r'^admin/', admin.site.urls),
+    path('admin/', admin.site.urls),
 ]


### PR DESCRIPTION
## Description

There was warnings `RemovedInDjango40Warning`
I removed them by changing `django.utils.translation.ugettext_lazy` to `django.utils.translation.gettext_lazy` and `django.conf.urls.url()` to `django.urls.re_path()`
## Checklist

- [x] Code builds clean without any errors or warnings
