### PR TITLE
asgoel/fix inline instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * removed RemovedInDjango40Warning warning message, thanks to @Ivan-Feofanov
+* fixed a bug where the handle_action function does not pass through parent objects into `get_inline_instances`
 
 ## [2.4.0] - 2021-02-08
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,4 @@
 - [@tony](https://github.com/tony)
 - [@tripliks](https://github.com/tripliks)
 - [@Ivan-Feofanov](https://github.com/Ivan-Feofanov)
+- [@asgoel](https://github.com/asgoel)

--- a/inline_actions/admin.py
+++ b/inline_actions/admin.py
@@ -254,7 +254,7 @@ class InlineActionsModelAdminMixin(BaseInlineActionsMixin):
                 # parent_obj is None because `object_id` is None
 
             else:
-                for inline in self.get_inline_instances(request):
+                for inline in self.get_inline_instances(request, obj=parent_obj):
                     inline_class_name = inline.__class__.__name__.lower()
                     matches_inline_class = inline_class_name == admin_class_name
                     matches_model = inline.model == model

--- a/test_proj/blog/admin.py
+++ b/test_proj/blog/admin.py
@@ -6,7 +6,7 @@ from inline_actions.actions import DefaultActionsMixin, ViewAction
 from inline_actions.admin import InlineActionsMixin, InlineActionsModelAdminMixin
 
 from . import forms
-from .models import Article, Author, AuthorProxy
+from .models import Article, Author, AuthorProxy, AuthorSecondProxy
 
 
 class UnPublishActionsMixin(object):
@@ -136,6 +136,17 @@ class AuthorAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
     inlines = [ArticleInline]
     list_display = ('name',)
     inline_actions = None
+
+
+@admin.register(AuthorSecondProxy)
+class AuthorMaybeInlineAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
+    list_display = ('name',)
+    inline_actions = None
+
+    def get_inlines(self, request, obj):
+        if not obj or obj.name != 'DISPLAY INLINE':
+            return []
+        return [ArticleInline]
 
 
 @admin.register(Article)

--- a/test_proj/blog/models.py
+++ b/test_proj/blog/models.py
@@ -38,3 +38,8 @@ class Article(models.Model):
 class AuthorProxy(Author):
     class Meta:
         proxy = True
+
+
+class AuthorSecondProxy(Author):
+    class Meta:
+        proxy = True


### PR DESCRIPTION
## Description

I noticed a bug (I think) where the handle action function does not pass through the parent object into the `get_inline_instances` function. Sometimes, a ModelAdmin will display or not display an inline(s) based on some property of the object itself. So, this function was error'ing out with a unbound `model_admin` instance since `get_inline_instances` was coming up with an empty list.

Fixes #(issue)

## Checklist

- [X] Tests covering the new functionality have been added
- [X] Code builds clean without any errors or warnings
- [X] Documentation has been updated
- [x] Changes have been added to the `CHANGELOG.md`
- [X] You added yourself to the `CONTRIBUTORS.md`
