### PR TITLE
Fixes #49, Handle custom admin pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * removed RemovedInDjango40Warning warning message, thanks to @Ivan-Feofanov
+* fixed #49, fixes reverse url lookup to handle custom admin pages.
 
 ## [2.4.0] - 2021-02-08
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -9,3 +9,4 @@
 - [@tony](https://github.com/tony)
 - [@tripliks](https://github.com/tripliks)
 - [@Ivan-Feofanov](https://github.com/Ivan-Feofanov)
+- [@bdnettleton](https://github.com/bdnettleton)

--- a/inline_actions/admin.py
+++ b/inline_actions/admin.py
@@ -202,7 +202,8 @@ class InlineActionsModelAdminMixin(BaseInlineActionsMixin):
         if parent_obj is None:  # InlineActionsMixin.MODEL_ADMIN:
             # redirect to `changelist`
             url = reverse(
-                'admin:{}_{}_changelist'.format(
+                '{}:{}_{}_changelist'.format(
+                    self.admin_site.name,
                     obj._meta.app_label,
                     obj._meta.model_name,
                 ),
@@ -210,7 +211,8 @@ class InlineActionsModelAdminMixin(BaseInlineActionsMixin):
         else:
             # redirect to `changeform`
             url = reverse(
-                'admin:{}_{}_change'.format(
+                '{}:{}_{}_change'.format(
+                    self.admin_site.name,
                     parent_obj._meta.app_label,
                     parent_obj._meta.model_name,
                 ),

--- a/test_proj/blog/custom_admin.py
+++ b/test_proj/blog/custom_admin.py
@@ -1,0 +1,82 @@
+from django.contrib import admin
+
+from inline_actions.actions import DefaultActionsMixin, ViewAction
+from inline_actions.admin import InlineActionsMixin, InlineActionsModelAdminMixin
+
+from .admin import (
+    ChangeTitleActionsMixin,
+    TogglePublishActionsMixin,
+    UnPublishActionsMixin,
+)
+from .models import Article, AuthorProxy
+
+
+class CustomAdminSite(admin.AdminSite):
+    site_header = "Custom admin"
+    site_title = "Custom Admin Portal"
+    index_title = "Welcome to Custom Administration"
+
+
+custom_admin = CustomAdminSite(name="custom_admin")
+
+
+class ArticleInline(
+    DefaultActionsMixin,
+    UnPublishActionsMixin,
+    TogglePublishActionsMixin,
+    InlineActionsMixin,
+    admin.TabularInline,
+):
+    model = Article
+    fields = (
+        'title',
+        'status',
+    )
+    readonly_fields = (
+        'title',
+        'status',
+    )
+
+    def has_add_permission(self, request, obj=None):
+        return False
+
+
+class ArticleNoopInline(InlineActionsMixin, admin.TabularInline):
+    model = Article
+    fields = (
+        'title',
+        'status',
+    )
+    readonly_fields = (
+        'title',
+        'status',
+    )
+
+    def get_inline_actions(self, request, obj=None):
+        actions = super(ArticleNoopInline, self).get_inline_actions(
+            request=request, obj=obj
+        )
+        actions.append('noop_action')
+        return actions
+
+    def noop_action(self, request, obj, parent_obj=None):
+        pass
+
+
+@admin.register(AuthorProxy, site=custom_admin)
+class AuthorMultipleInlinesAdmin(InlineActionsModelAdminMixin, admin.ModelAdmin):
+    inlines = [ArticleInline, ArticleNoopInline]
+    list_display = ('name',)
+    inline_actions = None
+
+
+@admin.register(Article, site=custom_admin)
+class ArticleAdmin(
+    UnPublishActionsMixin,
+    TogglePublishActionsMixin,
+    ChangeTitleActionsMixin,
+    ViewAction,
+    InlineActionsModelAdminMixin,
+    admin.ModelAdmin,
+):
+    list_display = ('title', 'status', 'author')

--- a/test_proj/urls.py
+++ b/test_proj/urls.py
@@ -1,6 +1,9 @@
 from django.contrib import admin
 from django.urls import path
 
+from test_proj.blog.custom_admin import custom_admin
+
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('custom_admin/', custom_admin.urls),
 ]


### PR DESCRIPTION
Simple changes in admin.py to change reverse url lookup to use the proper admin site name instead of always using the default "admin".

Includes new custom_admin page in test_proj and tests to check that the reverse url lookup works properly.

## Description

Simple changes in admin.py to change reverse url lookup to use the proper admin site name instead of always using the default "admin".

Includes new custom_admin page in test_proj and tests to check that the reverse url lookup works properly.

Fixes #49

## Checklist

- [x] Tests covering the new functionality have been added
- [x] Code builds clean without any errors or warnings
- [x] Documentation has been updated. (no documentation changes)
- [x] Changes have been added to the `CHANGELOG.md`
- [x] You added yourself to the `CONTRIBUTORS.md`
